### PR TITLE
Update MQ135.h

### DIFF
--- a/MQ135.h
+++ b/MQ135.h
@@ -22,9 +22,15 @@ v1.0 - First release
 #endif
 
 /// The load resistance on the board
+#ifndef RLOAD
 #define RLOAD 10.0
+#endif
+
 /// Calibration resistance at atmospheric CO2 level
+#ifndef RZERO
 #define RZERO 76.63
+#endif
+
 /// Parameters for calculating ppm of CO2 from sensor resistance
 #define PARA 116.6020682
 #define PARB 2.769034857


### PR DESCRIPTION
added #ifndef to RLOAD and RZERO, so that these can be configured in the sketch and platformio won't generate a warning while compiling.